### PR TITLE
Rpc version fix

### DIFF
--- a/GetworkStratumProxy/Network/PeekableNewLineDelimitedStream.cs
+++ b/GetworkStratumProxy/Network/PeekableNewLineDelimitedStream.cs
@@ -100,9 +100,7 @@ namespace GetworkStratumProxy.Network
             ReadStreamBuffer.Seek(readStreamBufferPosition, SeekOrigin.Begin);
 
             byte[] bytes = ReadStreamBuffer.ToArray();
-            string line = Encoding.UTF8.GetString(bytes);
-            Console.WriteLine(line);
-            return line;
+            return Encoding.UTF8.GetString(bytes);
         }
     }
 }

--- a/GetworkStratumProxy/Network/PeekableNewLineDelimitedStream.cs
+++ b/GetworkStratumProxy/Network/PeekableNewLineDelimitedStream.cs
@@ -39,9 +39,7 @@ namespace GetworkStratumProxy.Network
             else
             {
                 // Read straight from NetworkStream
-                Console.WriteLine("yeet");
                 bytesRead = base.Read(buffer, offset, count);
-                Console.WriteLine("yote");
             }
 
             return bytesRead;

--- a/GetworkStratumProxy/Network/PeekableNewLineDelimitedStream.cs
+++ b/GetworkStratumProxy/Network/PeekableNewLineDelimitedStream.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.IO;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GetworkStratumProxy.Network
+{
+    internal class PeekableNewLineDelimitedStream : Stream, IDisposable
+    {
+        private NetworkStream NetworkStream { get; }
+        private MemoryStream ReadStreamBuffer { get; }
+
+        public override bool CanRead => NetworkStream.CanRead;
+        public override bool CanSeek => NetworkStream.CanSeek;
+        public override bool CanWrite => NetworkStream.CanWrite;
+        public override long Length => NetworkStream.Length;
+        public override long Position
+        {
+            get => NetworkStream.Position;
+            set => NetworkStream.Position = value;
+        }
+
+        public PeekableNewLineDelimitedStream(NetworkStream networkStream)
+        {
+            NetworkStream = networkStream;
+            ReadStreamBuffer = new MemoryStream();
+        }
+
+        public override void Flush()
+        {
+            NetworkStream.Flush();
+        }
+
+        public new int ReadByte()
+        {
+            return ReadStreamBuffer.Position == ReadStreamBuffer.Length ? base.ReadByte() : ReadStreamBuffer.ReadByte();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            int bytesRead = 0;
+            // If any line of data exists in memory
+            if (ReadStreamBuffer.Position != ReadStreamBuffer.Length)
+            {
+                int current;
+                while (bytesRead < count && (current = ReadStreamBuffer.ReadByte()) != -1)
+                {
+                    if (bytesRead >= buffer.Length)
+                    {
+                        break;
+                    }
+
+                    buffer[offset + bytesRead] = (byte)current;
+                    bytesRead++;
+                }
+
+                // Clear internal buffer
+                ReadStreamBuffer.SetLength(0);
+            }
+            else
+            {
+                // ReadStreamBuffer did not fill buffer with enough data
+                // read more
+                byte[] networkBytes = new byte[count];
+                bytesRead = NetworkStream.Read(networkBytes, offset, count);
+                for (int i = 0; i < networkBytes.Length; i++)
+                {
+                    buffer[offset + i] = networkBytes[i];
+                }
+            }
+
+            return bytesRead;
+        }
+
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            return Read(buffer, offset, count);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            return NetworkStream.Seek(offset, origin);
+        }
+
+        public override void SetLength(long value)
+        {
+            NetworkStream.SetLength(value);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            NetworkStream.Write(buffer, offset, count);
+        }
+
+        public string PeekLine()
+        {
+            long readStreamBufferPosition = ReadStreamBuffer.Position;
+            int current;
+            while ((current = ReadByte()) != '\n')
+            {
+                ReadStreamBuffer.WriteByte((byte)current);
+            }
+            // Add line terminator
+            ReadStreamBuffer.WriteByte((byte)'\n');
+            ReadStreamBuffer.Seek(readStreamBufferPosition, SeekOrigin.Begin);
+
+            byte[] bytes = ReadStreamBuffer.ToArray();
+            return Encoding.UTF8.GetString(bytes);
+        }
+    }
+}

--- a/GetworkStratumProxy/Proxy/Client/EthProxyClient.cs
+++ b/GetworkStratumProxy/Proxy/Client/EthProxyClient.cs
@@ -49,8 +49,7 @@ namespace GetworkStratumProxy.Proxy.Client
         /// </summary>
         internal async Task StartListeningAsync()
         {
-            using var networkStream = TcpClient.GetStream();
-            using var peekableStream = new PeekableNewLineDelimitedStream(networkStream);
+            using var peekableStream = new PeekableNewLineDelimitedStream(TcpClient.GetStream().Socket);
             string line = peekableStream.PeekLine().Replace(": ", ":");
 
             using var formatter = new JsonMessageFormatter { ProtocolVersion = new Version(line.Contains("\"jsonrpc\":\"2.0\"") ? 2 : 1, 0) };

--- a/GetworkStratumProxy/Proxy/Client/EthProxyClient.cs
+++ b/GetworkStratumProxy/Proxy/Client/EthProxyClient.cs
@@ -1,11 +1,13 @@
 ﻿using GetworkStratumProxy.Extension;
 using GetworkStratumProxy.Network;
+using GetworkStratumProxy.Rpc;
 using Nethereum.Hex.HexTypes;
 using Nethereum.RPC.Eth.Mining;
 using StreamJsonRpc;
 using System;
 using System.IO;
 using System.Net.Sockets;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace GetworkStratumProxy.Proxy.Client
@@ -50,9 +52,9 @@ namespace GetworkStratumProxy.Proxy.Client
         internal async Task StartListeningAsync()
         {
             using var peekableStream = new PeekableNewLineDelimitedStream(TcpClient.GetStream().Socket);
-            string line = peekableStream.PeekLine().Replace(": ", ":");
+            var message = JsonSerializer.Deserialize<JsonRpcRequest>(peekableStream.PeekLine());
 
-            using var formatter = new JsonMessageFormatter { ProtocolVersion = new Version(line.Contains("\"jsonrpc\":\"2.0\"") ? 2 : 1, 0) };
+            using var formatter = new JsonMessageFormatter { ProtocolVersion = Version.Parse(message.JsonRpc ?? "1.0") };
             using var handler = new NewLineDelimitedMessageHandler(peekableStream, peekableStream, formatter);
             using var jsonRpc = new JsonRpc(handler, this);
 

--- a/GetworkStratumProxy/Rpc/JsonRpcRequest.cs
+++ b/GetworkStratumProxy/Rpc/JsonRpcRequest.cs
@@ -1,0 +1,12 @@
+﻿using System.Text.Json.Serialization;
+
+namespace GetworkStratumProxy.Rpc
+{
+    internal class JsonRpcRequest : JsonRpcMessage
+    {
+        [JsonPropertyName("method")]
+        public string Method { get; set; }
+        [JsonPropertyName("params")]
+        public object[] Params { get; set; }
+    }
+}


### PR DESCRIPTION
Fixes #11 (tried with TeamRedMiner [doesn't send jsonrpc at all, assumed 1.0] and PhoenixMiner [sends jsonrpc 2.0])
Fixes #9 (exceptions still trigger in debug mode but continuable) 

Will need to rewrite the entire network code to conform with how .NET works and correctly handle exceptions.